### PR TITLE
fix: switch off "auto_stop_machines" in supertokens' fly.auis.toml file

### DIFF
--- a/supertoken-core/fly.auis.toml
+++ b/supertoken-core/fly.auis.toml
@@ -12,7 +12,7 @@ primary_region = 'syd'
 [http_service]
   internal_port = 3567
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = "off"
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']


### PR DESCRIPTION
Turn off the "auto_stop_machines" in supertokens' fly.auis.toml file to potentially fix errors in auis-api. 